### PR TITLE
replaced product availability switches

### DIFF
--- a/backend/items/models.py
+++ b/backend/items/models.py
@@ -17,7 +17,7 @@ class Item(models.Model):
     )
 
     class Meta:
-        ordering = ['-stock']
+        #ordering = ['-stock']
         constraints = [models.UniqueConstraint(fields=['brand', 'name'], name='unique item')]
 
     def __str__(self):

--- a/frontend/src/views/Settings.vue
+++ b/frontend/src/views/Settings.vue
@@ -14,16 +14,11 @@
             <v-col cols="12" xs="12" sm="12" md="6" :class="[item.stock ? '' : 'grey--text', 'headline']">
               {{ item.brand }} {{item.name }}
             </v-col>
-            <v-col cols="12" xs="12" sm="6" md="2" :class="[item.stock ? '' : 'grey--text', 'headline']">
+            <v-col cols="12" xs="6" sm="6" md="2" :class="[item.stock ? '' : 'grey--text', 'headline']">
               {{ item.price | euro }}
             </v-col>
-            <v-col cols="12" xs="12" sm="6" md="2" class="text-center headline">
-              <v-btn v-if="item.stock" @click="toggleStock(item)">
-                <v-icon color="red darken-4">mdi-do-not-disturb</v-icon>
-              </v-btn>
-              <v-btn v-else @click="toggleStock(item)">
-                <v-icon color="green darken-4">mdi-plus-circle</v-icon>
-              </v-btn>
+            <v-col cols="12" xs="6" sm="6" md="2" class="text-center headline">
+              <v-switch :input-value="item.stock" @change="toggleStock(item)" color="info" :label="item.stock ? 'verfügbar' : 'nicht verfügbar'">
             </v-col>
          </v-row>
          </v-card-text>


### PR DESCRIPTION
This provides a clear way to switch between product availabilities

New:
![image](https://user-images.githubusercontent.com/948965/97456348-14ef7600-1939-11eb-97cb-4368c9e97577.png)

Old:
![image](https://user-images.githubusercontent.com/948965/97456550-45cfab00-1939-11eb-8b26-6b615ddaf735.png)
